### PR TITLE
Makefile to create production-grade all-in-one yaml for Kyverno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+NAME ?= kyverno
+REPOSITORY ?= kyverno
+KYVERNO-HELM ?= "https://kyverno.github.io/$(NAME)/"
+
+NAMESPACE ?= kyverno
+
+.PHONY: add
+add: helm
+	$(LOCALBIN)/helm repo add $(REPOSITORY) $(KYVERNO-HELM)
+
+.PHONY: template
+template: add
+## Use the securityContext=null flag for OpenShift usage, as explained in the 
+## Kyverno installation guide (https://kyverno.io/docs/installation/#notes-for-openshift-users)
+	$(LOCALBIN)/helm template $(NAME) $(REPOSITORY)/$(NAME) --output-dir $(MANIFESTS) --set securityContext=null --set replicaCount=3 --set namespace=$(NAMESPACE) --create-namespace --namespace $(NAMESPACE)
+
+.PHONY: patch-node
+patch-node: template
+## In order to allow Kyverno policies on nodes, we need to
+## remove the Node filter from the Kyverno ConfigMap
+	sed -i 's/\[Node,\*,\*\]//g' $(MANIFESTS)/$(NAME)/templates/configmap.yaml
+
+.PHONY: build
+build: template
+	echo -n > $(MANIFESTS)/kyverno.yml
+	cat $(MANIFESTS)/namespace.yaml >> $(MANIFESTS)/kyverno.yaml
+	for f in $(MANIFESTS)/$(NAME)/templates/*.yaml ; do cat $$f >> $(MANIFESTS)/kyverno.yml ; done
+
+##@ Build Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Location to put manifests in
+MANIFESTS ?= $(shell pwd)/manifests
+$(MANIFESTS):
+	mkdir -p $(MANIFESTS)
+
+## Tool Versions
+HELM_VERSION ?= v3.10.3
+
+## Tool Binaries
+HELM ?= $(LOCALBIN)/helm
+HELM_BINARY ?= linux-amd64
+
+HELM_DOWNLOAD ?= "https://get.helm.sh/helm-$(HELM_VERSION)-$(HELM_BINARY).tar.gz"
+
+.PHONY: helm
+helm: $(HELM) ## Download helm locally if necessary.
+$(HELM): $(LOCALBIN)
+	test -s $(LOCALBIN)/helm || { wget -q $(HELM_DOWNLOAD) && tar -zxf helm-$(HELM_VERSION)-$(HELM_BINARY).tar.gz && mv $(HELM_BINARY)/helm $(LOCALBIN)/helm && rm -rf linux-amd64 helm-$(HELM_VERSION)-$(HELM_BINARY).tar.gz; }

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ The following table summarizes the policies that exist in this repository:
 | `deny-default-scc` 	| Prevents modification of default SCCs `anyuid`, `hostaccess`, `hostmount-anyuid`, `hostnetwork`, `hostnetwork-v2`, `node-exporter`, `nonroot`, `nonroot-v2`, `privileged`, `restricted`, `restricted-v2` 	|
 | `deny-node-update` 	| Prevents modification of a node 	|
 | `deny-prometheus-rule` 	| Prevents creation of a PrometheusRule in RKS managed namespaces 	|
+
+## Build
+In order to create a single YAML containing the latest `Kyverno` manifests, use the `make build` directive of the `Makefile`.
+
+```
+$ make build
+```
+
+The output is a `manifests/kyverno.yaml` file which can be used to deploy `Kyverno` on an OpenShift cluster and can be used in Production, as per the `Kyverno` [installation page](https://kyverno.io/docs/installation/). including the changes needed to enable the `Node` [policy](https://kyverno.io/policies/other/protect_node_taints/protect-node-taints/).

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: kyverno
+    app: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno


### PR DESCRIPTION
Added a Makefile that uses the Helm chart of Kyverno (the only supported method for Kyverno in production) in order to create an all-in-one YAML file with the necessary changes for OpenShift

Signed-off-by: mzeevi <meytar80@gmail.com>