### PR TITLE
added support for offline bundle installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,14 @@ patch-node: template
 
 .PHONY: build
 build: template
-	echo -n > $(MANIFESTS)/kyverno.yml
+	echo -n > $(MANIFESTS)/kyverno.yaml
 	cat $(MANIFESTS)/namespace.yaml >> $(MANIFESTS)/kyverno.yaml
-	for f in $(MANIFESTS)/$(NAME)/templates/*.yaml ; do cat $$f >> $(MANIFESTS)/kyverno.yml ; done
+	for f in $(MANIFESTS)/$(NAME)/templates/*.yaml ; do cat $$f >> $(MANIFESTS)/kyverno.yaml ; done
+
+.PHONY: unbuild
+unbuild:
+	rm -r $(MANIFESTS)/$(NAME)
+	rm $(MANIFESTS)/kyverno.yaml
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ build: template
 
 .PHONY: build-offline
 build-offline: build
-	chmod +x $(OFFLINE-SCRIPT)
-	bash $(OFFLINE-SCRIPT) -c $(MANIFESTS)
+	bash $(OFFLINE-SCRIPT) -c
+
+.PHONY: unpack-offline
+unpack-offline:
+	bash $(OFFLINE-SCRIPT) -p -r $(INTERNAL-REGISTRY)
 
 .PHONY: unbuild
 unbuild:
@@ -50,6 +53,9 @@ $(MANIFESTS):
 
 # Location to search for images for offline installation
 OFFLINE-SCRIPT ?= $(shell pwd)/scripts/offline-bundle.sh
+
+# Private registry for offline installation
+INTERNAL-REGISTRY ?= my.registry.com:5000/X/Y
 
 ## Tool Versions
 HELM_VERSION ?= v3.10.3

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ build: template
 	cat $(MANIFESTS)/namespace.yaml >> $(MANIFESTS)/kyverno.yaml
 	for f in $(MANIFESTS)/$(NAME)/templates/*.yaml ; do cat $$f >> $(MANIFESTS)/kyverno.yaml ; done
 
+.PHONY: build-offline
+build-offline: build
+	chmod +x $(OFFLINE-SCRIPT)
+	bash $(OFFLINE-SCRIPT) -c $(MANIFESTS)
+
 .PHONY: unbuild
 unbuild:
 	rm -r $(MANIFESTS)/$(NAME)
@@ -42,6 +47,9 @@ $(LOCALBIN):
 MANIFESTS ?= $(shell pwd)/manifests
 $(MANIFESTS):
 	mkdir -p $(MANIFESTS)
+
+# Location to search for images for offline installation
+OFFLINE-SCRIPT ?= $(shell pwd)/scripts/offline-bundle.sh
 
 ## Tool Versions
 HELM_VERSION ?= v3.10.3

--- a/README.md
+++ b/README.md
@@ -19,11 +19,86 @@ The following table summarizes the policies that exist in this repository:
 | `deny-node-update` 	| Prevents modification of a node 	|
 | `deny-prometheus-rule` 	| Prevents creation of a PrometheusRule in RKS managed namespaces 	|
 
-## Build
+## Build for OpenShift
+The only supported way to install Kyverno in Production is using `helm`. However, at times it's more preferable to create an `all-in-one.yaml` that can be installed using `kubectl`.
+
+A `Makfile` takes care of all the things necessary in order to install Kyverno on OpenShift and in an offline environment.
+
 In order to create a single YAML containing the latest `Kyverno` manifests, use the `make build` directive of the `Makefile`.
 
 ```
-$ make build
+make build
 ```
 
 The output is a `manifests/kyverno.yaml` file which can be used to deploy `Kyverno` on an OpenShift cluster and can be used in Production, as per the `Kyverno` [installation page](https://kyverno.io/docs/installation/). including the changes needed to enable the `Node` [policy](https://kyverno.io/policies/other/protect_node_taints/protect-node-taints/).
+
+## Offline Installation
+`Kyverno` does not have built-in support for installation in an offline environment, but a `Makefile` entry takes care of it so there's a way to make the process easier.
+
+The `offline-bundle.sh` script can be used to create a package usable for offline installation of the operator. 
+
+The process is heavily inspired by [Offline Installation of Dell CSI Storage Providers](https://github.com/dell/dell-csi-operator/blob/main/scripts/csi-offline-bundle.md).
+
+### Workflow
+To perform an offline installation, the following steps should be performed:
+1. Build an offline bundle.
+2. Unpacking the offline bundle created in Step 1 and preparing for installation.
+3. Perform an installation using the files obtained after unpacking in Step 2.
+
+*NOTE: It is recommended to use the same build tool for packing and unpacking of images (either `docker` or `podman`).*
+
+### Building an offline bundle
+This needs to be performed on a Linux system with access to the internet as a git repo will need to be cloned, and container images pulled from public registries.
+
+To build an offline bundle, the following steps are needed:
+
+1. Perform a `git clone` of the desired repository:
+    ```
+    git clone https://github.com/dana-team/managed-cluster-validating-kyverno.git
+    ```
+
+2. Use the `Makefile` entry in order to create an offline bundle:
+    ```
+    make build-offline
+    ```
+
+The will perform the following steps:
+
+- Determine required images by parsing the manifests.
+- Perform an image pull of each image required.
+- Save all required images to a file by running `docker save` or `podman save`.
+- Build a `tar.gz` file containing the images as well as files required to install the operator.
+
+
+### Unpacking the offline bundle and preparing for installation
+This needs to be performed on a Linux system with access to an image registry that will host container images. If the registry requires login, that should be done before proceeding.
+
+To prepare for installation, the following steps need to be performed:
+
+1. Copy the offline bundle file created from the previous step to a system with access to an image registry available to your OpenShift cluster.
+
+2. Expand the bundle file by running: 
+    ```
+    tar xvfz <filename>
+    ```
+
+3. Run the `offline-bundle.sh` script and supply the `-p` option as well as the path to the internal registry with the `-r` option:
+    ```
+    make unpack-offline INTERNAL-REGISTRY=<path to internal registry>
+    ```
+
+The script will then perform the following steps:
+
+- Load the required container images into the local system
+- Tag the images according to the user-supplied registry information
+- Push the newly tagged images to the registry
+- Modify the manifests to refer to the newly tagged/pushed images
+
+### Install
+Run installation of the `all-in-one.yaml` in your favorite way. For example:
+
+```
+kubectl create -f manifests/kyverno.yaml
+```
+
+*Note: You may need to use `kubectl create` instead of `kubectl apply`.*

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following table summarizes the policies that exist in this repository:
 ## Build for OpenShift
 The only supported way to install Kyverno in Production is using `helm`. However, at times it's more preferable to create an `all-in-one.yaml` that can be installed using `kubectl`.
 
-A `Makfile` takes care of all the things necessary in order to install Kyverno on OpenShift and in an offline environment.
+A `Makefile` takes care of all the things necessary in order to install Kyverno on OpenShift and in an offline environment.
 
 In order to create a single YAML containing the latest `Kyverno` manifests, use the `make build` directive of the `Makefile`.
 

--- a/scripts/offline-bundle.sh
+++ b/scripts/offline-bundle.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# bundle manifests, installation scripts, and
+# container images into a tarball that can be used for offline installations
+
+# display some usage information
+usage() {
+   echo
+   echo "$0"
+   echo "Make a package for offline installation of a CSI driver"
+   echo
+   echo "Arguments:"
+   echo "-c             Create an offline bundle"
+   echo "-p             Prepare this bundle for installation"
+   echo "-r <registry>  Required if preparing offline bundle with '-p'"
+   echo "               Supply the registry name/path which will hold the images"
+   echo "               For example: my.registry.com:5000/X/Y"
+   echo "-h             Displays this information"
+   echo
+   echo "Exactly one of '-c' or '-p' needs to be specified"
+   echo
+}
+
+# status
+# echos a brief status sttement to stdout
+status() {
+  echo
+  echo "*"
+  echo "* $@"
+  echo 
+}
+
+# run_command
+# runs a shell command
+# exits and prints stdout/stderr when a non-zero return code occurs
+run_command() {
+  CMDOUT=$(eval "${@}" 2>&1)
+  local rc=$?
+
+  if [ $rc -ne 0 ]; then
+    echo
+    echo "ERROR"
+    echo "Received a non-zero return code ($rc) from the following comand:"
+    echo "  ${@}"
+    echo
+    echo "Output was:"
+    echo "${CMDOUT}"
+    echo
+    echo "Exiting"
+    exit 1
+  fi
+}
+
+# build_image_manifest
+# builds a manifest of all the images referred to by the helm chart
+build_image_manifest() {
+  local REGEX="([-_./:A-Za-z0-9]{3,}):([-_.A-Za-z0-9]{1,})"
+
+  status "Building image manifest file"
+  if [ -e "${IMAGEFILEDIR}" ]; then
+    rm -rf "${IMAGEFILEDIR}"
+  fi
+  if [ -f "${IMAGEMANIFEST}" ]; then
+    rm -rf "${IMAGEMANIFEST}"
+  fi
+
+  for D in ${DIRS_FOR_IMAGE_NAMES[@]}; do
+    echo "   Processing files in ${D}"
+    if [ ! -d "${D}" ]; then
+      echo "Unable to find directory, ${D}. Skipping"
+    else
+      # look for strings that appear to be image names, this will
+      # - search all files in a diectory looking for strings that make $REGEX
+      # - exclude anything with double '//'' as that is a URL and not an image name
+      # - make sure at least one '/' is found
+      find "${D}" -type f -exec egrep -oh "${REGEX}" {} \; | egrep -v '//' | egrep '/' >> "${IMAGEMANIFEST}.tmp"
+    fi
+  done
+
+  # sort and uniqify the list
+  cat "${IMAGEMANIFEST}.tmp" | sort | uniq > "${IMAGEMANIFEST}"
+  rm "${IMAGEMANIFEST}.tmp"
+}
+
+# archive_images
+# archive the necessary docker images by pulling them locally and then saving them
+archive_images() {
+  status "Pulling and saving container images"
+
+  if [ ! -d "${IMAGEFILEDIR}" ]; then
+    mkdir -p "${IMAGEFILEDIR}"
+  fi
+
+  # the images, pull first in case some are not local
+  while read line; do
+      echo "   $line"
+      run_command "${DOCKER}" pull "${line}"
+      IMAGEFILE=$(echo "${line}" | sed 's|[/:]|-|g')
+      # if we already have the image exported, skip it
+      if [ ! -f "${IMAGEFILEDIR}/${IMAGEFILE}.tar" ]; then
+        run_command "${DOCKER}" save -o "${IMAGEFILEDIR}/${IMAGEFILE}.tar" "${line}"
+      fi
+  done < "${IMAGEMANIFEST}"
+
+} 
+
+# restore_images
+# load the images from an archive into the local registry
+# then push them to the target registry
+restore_images() {
+  status "Loading docker images"
+  find "${IMAGEFILEDIR}" -name \*.tar -exec "${DOCKER}" load -i {} \; 2>/dev/null
+
+  status "Tagging and pushing images"
+  while read line; do
+      local NEWNAME="${REGISTRY}${line##*/}"
+      echo "   $line -> ${NEWNAME}"
+      run_command "${DOCKER}" tag "${line}" "${NEWNAME}"
+      run_command "${DOCKER}" push "${NEWNAME}"
+  done < "${IMAGEMANIFEST}"
+}
+
+# copy in any necessary files
+copy_files() {
+  status "Copying necessary files"
+  for f in ${REQUIRED_FILES[@]}; do
+    echo " ${f}"
+    cp -R "${f}" "${DISTDIR}"
+    if [ $? -ne 0 ]; then
+      echo "Unable to copy ${f} to the distribution directory"
+      exit 1
+    fi
+  done
+}
+
+# fix any references in the helm charts or operator configuration
+fixup_files() {
+
+  local ROOTDIR="${HELMDIR}"
+
+  if [ "${MODE}" == "operator" ]; then
+    ROOTDIR="${REPODIR}"
+  fi
+
+  status "Preparing ${MODE} files within ${ROOTDIR}"
+
+  # for each image in the manifest, replace the old name with the new
+  while read line; do
+      local NEWNAME="${REGISTRY}${line##*/}"
+      echo "   changing: $line -> ${NEWNAME}"
+      find "${ROOTDIR}" -type f -not -path "${SCRIPTDIR}/*" -exec sed -i "s|$line|$NEWNAME|g" {} \;
+  done < "${IMAGEMANIFEST}"
+}
+
+# compress the whole bundle
+compress_bundle() {
+  status "Compressing release"
+  cd "${DISTBASE}" && tar cvfz "${DISTFILE}" "${DRIVERDIR}"
+  if [ $? -ne 0 ]; then
+    echo "Unable to package build"
+    exit 1
+  fi
+  rm -rf "${DISTDIR}"
+}
+
+#------------------------------------------------------------------------------
+#
+# Main script logic starts here
+#
+
+# default values, overridable by users
+CREATE="false"
+PREPARE="false"
+REGISTRY=""
+
+# some directories
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPODIR="$( dirname "${SCRIPTDIR}" )"
+
+DRIVERNAME="offline-operator"
+DISTBASE="${REPODIR}"
+DRIVERDIR="${DRIVERNAME}-bundle"
+DISTDIR="${DISTBASE}/${DRIVERDIR}"
+DISTFILE="${DISTBASE}/${DRIVERDIR}.tar.gz"
+IMAGEMANIFEST="${REPODIR}/scripts/images.manifest"
+IMAGEFILEDIR="${REPODIR}/scripts/images.tar"
+MANIFESTSDIR=$2
+
+# directories to search all files for image names
+DIRS_FOR_IMAGE_NAMES=(
+  "${MANIFESTSDIR}"
+)
+
+# list of all files to be included
+REQUIRED_FILES=(
+  "${REPODIR}/manifests"
+  "${REPODIR}/policies"
+  "${REPODIR}/scripts"
+  "${REPODIR}/*.md"
+)
+
+while getopts "cpr:h" opt; do
+  case $opt in
+    c)
+      CREATE="true"
+      ;;
+    p)
+      PREPARE="true"
+      ;;
+    r)
+      REGISTRY="${OPTARG}"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# make sure exatly one option for create/prepare was specified
+if [ "${CREATE}" == "${PREPARE}" ]; then
+  usage
+  exit 1
+fi
+
+# validate prepare arguments
+if [ "${PREPARE}" == "true" ]; then
+  if [ "${REGISTRY}" == "" ]; then
+    usage
+    exit 1
+  fi
+fi
+
+if [ "${REGISTRY: -1}" != "/" ]; then
+  REGISTRY="${REGISTRY}/"
+fi
+
+# figure out if we should use docker or podman, preferring docker
+DOCKER=$(which docker 2>/dev/null || which podman 2>/dev/null)   
+if [ "${DOCKER}" == "" ]; then
+  echo "Unable to find either docker or podman in $PATH"
+  exit 1
+fi
+
+# create a bundle
+if [ "${CREATE}" == "true" ]; then
+  if [ -d "${DISTDIR}" ]; then
+    rm -rf "${DISTDIR}"
+  fi
+  if [ ! -d "${DISTDIR}" ]; then
+    mkdir -p "${DISTDIR}"
+  fi
+  if [ -f "${DISTFILE}" ]; then
+    rm -f "${DISTFILE}"
+  fi
+  build_image_manifest
+  archive_images
+  copy_files
+  compress_bundle
+
+  status "Complete"
+  echo "Offline bundle file is: ${DISTFILE}"
+fi
+
+# prepare a bundle for installation
+if [ "${PREPARE}" == "true" ]; then
+  echo "Preparing a offline bundle for installation"
+  restore_images
+  copy_helm_dir
+  fixup_files
+
+  status "Complete"
+fi
+
+echo
+
+exit 0

--- a/scripts/offline-bundle.sh
+++ b/scripts/offline-bundle.sh
@@ -190,7 +190,7 @@ DISTDIR="${DISTBASE}/${DRIVERDIR}"
 DISTFILE="${DISTBASE}/${DRIVERDIR}.tar.gz"
 IMAGEMANIFEST="${REPODIR}/scripts/images.manifest"
 IMAGEFILEDIR="${REPODIR}/scripts/images.tar"
-MANIFESTSDIR=$2
+MANIFESTSDIR="${REPODIR}/manifests"
 
 # directories to search all files for image names
 DIRS_FOR_IMAGE_NAMES=(


### PR DESCRIPTION
With this PR, users can now use the offline-bundle.sh script in order to create an offline bundle of the operator containing the necessary manifests and policies as well as a script to install inside an offline environment
    
Signed-off-by: mzeevi <meytar80@gmail.com>